### PR TITLE
Windows Arm64 Compatibility

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -16,7 +16,7 @@
     target: [
       {
         target: "nsis",
-        arch: ["x64", "ia32"],
+        arch: ["x64", "ia32", "arm64"],
       },
     ],
     artifactName: "${productName}-Windows-${version}-Setup.${ext}",


### PR DESCRIPTION
Vapour appears to build without issue for Arm64 with one minuscule change, so I figured I'd submit a pull request to get it in the main repo. The official Steam client doesn't have an Arm64 release, so this is a nice stopgap despite the lack of actual Arm-native games, since Windows 11's x64 emulation seems to guzzle memory, making it less than ideal for background processes.